### PR TITLE
better update check, parse filename from error messages

### DIFF
--- a/lib/errorview.coffee
+++ b/lib/errorview.coffee
@@ -1,5 +1,7 @@
 {View, $$} = require 'space-pen'
 
+LINE_MATCH = /\s*File\s"((?:[^"]|[\\"])+)", line ([0-9]+)/gi
+
 module.exports =
 class ErrorView extends View
 
@@ -47,10 +49,16 @@ class ErrorView extends View
     @root.append(li)
 
   addMessage: (message) ->
-
+    # we look for a message like parse error to extract file and linenumber
+    match = LINE_MATCH.exec(message)
     li = $$ ->
+      @div class: 'filename', match[1]+':'+match[2] if match
       @li class: 'message', =>
         @div class: 'code', message
+    if match
+      li.on 'click', =>
+        atom.workspace.open match[1], initialLine: match[2]-1, searchAllPanes: true
+
 
     @root.append(li)
 

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -12,7 +12,7 @@ module.exports = PythonNosetestsRunner =
     #   - settings.success( <content of nosetests.json> )
     #   - settings.error( <errormessage> )
 
-    start_time = new Date().getTime()/1000;
+    last_run = null
 
     current_dir = @getCurrentDir()
 
@@ -29,13 +29,13 @@ module.exports = PythonNosetestsRunner =
       filecontent = fs.readFileSync(nosetestsfile, 'UTF8');
       data = JSON.parse(filecontent)
       command = data.metadata.command
+      last_run = data.metadata.time
       cwd = data.metadata.cwd
       @last_nosetestsfile = nosetestsfile
 
     else
       settings.error "Could not find 'nosetests.json' in any of the parent folders of the active file."
       return
-
 
     child_process.exec command, cwd: cwd, =>
 
@@ -46,8 +46,8 @@ module.exports = PythonNosetestsRunner =
       filecontent = fs.readFileSync(nosetestsfile, 'UTF8');
       data = JSON.parse(filecontent)
 
-      if data.metadata.time < start_time
-        settings.error 'Error: timestamp of nosetests.json file is before starting time.'
+      if last_run and data.metadata.time == last_run
+        settings.error 'Error: timestamp of nosetests.json did not update'
         return
 
       settings.success data


### PR DESCRIPTION
Did a better update check. It causes here some error messages even nosetest ran through.
it no tries to parse the output of the error message to find the file with parse errors.
the regexp may be suboptimal, depending on the localization of the environment, maybe replace file and line with .+ and hope it matches most ? :)
